### PR TITLE
Use `AutoSaveSession` function instead so auto session configs are respected

### DIFF
--- a/lua/telescope/_extensions/session-lens/session-lens-actions.lua
+++ b/lua/telescope/_extensions/session-lens/session-lens-actions.lua
@@ -7,7 +7,7 @@ local SessionLensActions = {}
 SessionLensActions.source_session = function(prompt_bufnr)
   local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
-  AutoSession.SaveSession()
+  AutoSession.AutoSaveSession()
   vim.cmd("%bd!")
   AutoSession.RestoreSession(selection.path)
 end


### PR DESCRIPTION
Closes #5 

This should make it so the options in auto-session are checked before saving a session.