### PR TITLE
Fixed and uncommented entry maker function

### DIFF
--- a/lua/telescope/_extensions/session-lens/main.lua
+++ b/lua/telescope/_extensions/session-lens/main.lua
@@ -9,7 +9,6 @@ local SessionLens = {
 
 local defaultConf = {
   theme_conf = { winblend = 10, border = true },
-  path_display = {'shorten'},
   previewer = false
 }
 
@@ -59,7 +58,7 @@ SessionLens.search_session = function(custom_opts)
 
   local opts = {
     prompt_title = 'Sessions',
-    -- entry_maker = Lib.make_entry.gen_from_file({cwd = cwd, path_display = path_display}),
+    entry_maker = Lib.make_entry.gen_from_file(custom_opts),
     cwd = cwd,
     -- TOOD: support custom mappings?
     attach_mappings = function(_, map)

--- a/lua/telescope/_extensions/session-lens/session-lens-library.lua
+++ b/lua/telescope/_extensions/session-lens/session-lens-library.lua
@@ -1,5 +1,6 @@
--- local path = require('plenary.path')
--- local utils = require('telescope.utils')
+local path = require('plenary.path')
+local AutoSession = require('auto-session')
+local AutoSessionLib = require('auto-session-library')
 
 local Config = {}
 local Lib = {
@@ -72,64 +73,26 @@ end
 
 
 -- ==================== SessionLens ==========================
--- do
---   local lookup_keys = {
---     ordinal = 1,
---     value = 1,
---     filename = 1,
---     cwd = 2,
---   }
-
---   function Lib.make_entry.gen_from_file(opts)
---     opts = opts or {}
-
---     local cwd = vim.fn.expand(opts.cwd or vim.fn.getcwd())
-
---     local path_display = opts.path_display
-
---     local mt_file_entry = {}
-
---     mt_file_entry.cwd = cwd
---     mt_file_entry.display = function(entry)
---       -- Revert session files back to paths for easier reading
---       -- This affects the display only, a selection still uses the correct file name.
---       local is_win32 = vim.fn.has('win32') == Lib._VIM_TRUE
---       local entry_value = entry.value:gsub("%%", "/")
---       local display = is_win32 and path.make_relative(entry_value:gsub("%++", ":"), cwd) or path.make_relative(entry_value, cwd)
-
---       -- there problem with telescope path_shorten() for windows
---       -- see https://github.com/nvim-telescope/telescope.nvim/issues/706
---       if vim.tbl_contains(path_display, "shorten") and not is_win32 then
---         display = path.shorten(display)
---       end
-
---       -- Strip file extensions since sessions always have the same .vim extension.
---       local filename_only = display:match("(.+)%..+")
-
---       return filename_only
---     end
-
---     -- No idea what this block does, got it from the telescope code, may or may not figure it out later.
---     mt_file_entry.__index = function(t, k)
---       local raw = rawget(mt_file_entry, k)
---       if raw then return raw end
-
---       if k == "path" then
---         local retpath = t.cwd .. path.separator .. t.value
---         if not vim.loop.fs_access(retpath, "R", nil) then
---           retpath = t.value
---         end
---         return retpath
---       end
-
---       return rawget(t, rawget(lookup_keys, k))
---     end
-
---     return function(line)
---       return setmetatable({line}, mt_file_entry)
---     end
---   end
--- end
+function Lib.make_entry.gen_from_file(opts)
+  local root = AutoSession.get_root_dir()
+  return function(line)
+    return {
+      ordinal = line,
+      value = line,
+      filename = line,
+      cwd = root,
+      display = function(_)
+        local out = AutoSessionLib.unescape_dir(line):match("(.+)%.vim")
+        if opts.path_display and vim.tbl_contains(opts.path_display, "shorten") then
+          out = path:new(out):shorten()
+        end
+        if out then return out end
+        return line
+      end,
+      path = path:new(root, line):absolute()
+    }
+  end
+end
 -- ===================================================================================
 
 -- Logger =========================================================


### PR DESCRIPTION
Previous commented function was overcomplicated.
It constructed return dictionary using `setmetatable`
and object with custom `__index`.
I know this was taken straight from the telescope source
code but this dictionary can be just constructed directly.
Also fixed `path` usages.