### PR TITLE
Fix telescope action timing problems, in particular related to folding

### DIFF
--- a/lua/telescope/_extensions/session-lens/session-lens-actions.lua
+++ b/lua/telescope/_extensions/session-lens/session-lens-actions.lua
@@ -7,16 +7,20 @@ local SessionLensActions = {}
 SessionLensActions.source_session = function(prompt_bufnr)
   local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
-  AutoSession.AutoSaveSession()
-  vim.cmd("%bd!")
-  AutoSession.RestoreSession(selection.path)
+  vim.defer_fn(function ()
+    AutoSession.AutoSaveSession()
+    vim.cmd("%bd!")
+    AutoSession.RestoreSession(selection.path)
+  end, 50)
 end
 
 -- TODO: make this refresh the picker and not close it instead
 SessionLensActions.delete_session = function(prompt_bufnr)
   local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
-  AutoSession.DeleteSession(selection.path)
+  vim.defer_fn(function ()
+    AutoSession.DeleteSession(selection.path)
+  end, 50)
 end
 
 return SessionLensActions


### PR DESCRIPTION
When calling `actions.close(prompt_bufnr)` it does not close telescope immediately. Thus Restoring / Saving sessions / Deleting buffers before telescope is completely closed is problematic. I don't think however it is a problem with the way auto-session is implemented, as much as a telescope problem, see https://github.com/nvim-telescope/telescope.nvim/issues/699.
More specifically this PR fixes folding problems when switching to a session that has folds in a window.
```
E5108: Error executing lua ...k/packer/start/auto-session/lua/auto-session-library.lua:189:         Error restoring session! The session might be corrupted.
        Disabling auto save. Please check for errors in your config. Error:
      Vim(normal):E490: No fold found
...
```
Actually I think this PR might fix other problems related to how telescope handles actions, but folding was the most specific example.
The idea is to add a delay before doing anything auto-session related, such that telescope has been closed properly. Ideally this should not be neccesary, but I don't know when the [telescope issue](https://github.com/nvim-telescope/telescope.nvim/issues/699) will be fixed.