### PR TITLE
Don't discard theme_conf after one use

### DIFF
--- a/lua/telescope/_extensions/session-lens/main.lua
+++ b/lua/telescope/_extensions/session-lens/main.lua
@@ -41,7 +41,6 @@ SessionLens.search_session = function(custom_opts)
   end
 
   local theme_opts = themes.get_dropdown(custom_opts.theme_conf)
-  custom_opts["theme_conf"] = nil
 
   -- Ignore last session dir on finder if feature is enabled
   if AutoSession.conf.auto_session_enable_last_session then


### PR DESCRIPTION
`theme_conf` passed to the setup function only works for the first use. Then it's deleted by [line 44](https://github.com/rmagatti/session-lens/blob/5e95ad9aec94b34c83db3eff5dabc4ca1778de6d/lua/telescope/_extensions/session-lens/main.lua#L44) (on [line 27](https://github.com/rmagatti/session-lens/blob/5e95ad9aec94b34c83db3eff5dabc4ca1778de6d/lua/telescope/_extensions/session-lens/main.lua#L27) `custom_opts` is set as a reference to `SessionLens.conf`). This PR removes line 44. I tested it and nothing broke, but I'm not familiar with telescopes API and if you think this line is necessary, you can change line 27 to `custom_opts = (Lib.isEmptyTable(custom_opts) or custom_opts == nil) and vim.deepcopy(SessionLens.conf) or custom_opts` instead to fix this issue as well.