### PR TITLE
Feat/theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ require('session-lens').setup {
 }
 ```
 
-Another example would be changing how the dropdown looks, this can be done by setting the `theme_conf` in the setup opts.
-The options in `theme_conf` get passed into `require('telescope.themes').get_dropdown(theme_conf)`, so anything supported by `get_dropdown` can be used here as well.
+Another example would be changing how the dropdown looks, this can be done by setting the `theme` and `theme_conf` in the setup options.
+The options in `theme_conf` get passed into `require('telescope.themes').get_dropdown(theme_conf)`, so anything supported by `get_dropdown` (or the function that corresponds to the specified `theme`) can be used here as well.
 ```lua
 require('session-lens').setup {
   path_display = {'shorten'},
+  theme = 'ivy', -- default is dropdown
   theme_conf = { border = false },
   previewer = true
 }

--- a/lua/telescope/_extensions/session-lens/main.lua
+++ b/lua/telescope/_extensions/session-lens/main.lua
@@ -7,8 +7,10 @@ local SessionLens = {
   conf = {}
 }
 
+local default_theme = "dropdown"
+
 local defaultConf = {
-  theme = { 'dropdown' },
+  theme = default_theme,
   theme_conf = { winblend = 10, border = true },
   previewer = false
 }
@@ -41,7 +43,13 @@ SessionLens.search_session = function(custom_opts)
     custom_opts.shorten_path = nil
   end
 
-  local theme_opts = themes['get_' .. custom_opts.theme](custom_opts.theme_conf)
+	-- error if there is no corresponding function for the user-specified theme in telescope.themes
+	if not themes["get_" .. custom_opts.theme] then
+		Lib.logger.error("invalid theme specified")
+		return
+	end
+
+	local theme_opts = themes["get_" .. custom_opts.theme](custom_opts.theme_conf)
 
   -- Ignore last session dir on finder if feature is enabled
   if AutoSession.conf.auto_session_enable_last_session then

--- a/lua/telescope/_extensions/session-lens/main.lua
+++ b/lua/telescope/_extensions/session-lens/main.lua
@@ -8,6 +8,7 @@ local SessionLens = {
 }
 
 local defaultConf = {
+  theme = { 'dropdown' },
   theme_conf = { winblend = 10, border = true },
   previewer = false
 }
@@ -40,7 +41,7 @@ SessionLens.search_session = function(custom_opts)
     custom_opts.shorten_path = nil
   end
 
-  local theme_opts = themes.get_dropdown(custom_opts.theme_conf)
+  local theme_opts = themes['get_' .. custom_opts.theme](custom_opts.theme_conf)
 
   -- Ignore last session dir on finder if feature is enabled
   if AutoSession.conf.auto_session_enable_last_session then


### PR DESCRIPTION
Add support for user-provided theme in plugin config.

For instance with the following config we can get a session picker with the `ivy` theme, and use `theme_conf` to change its height:

```lua
require('session-lens').setup({
  theme = 'ivy',
  theme_conf = {
    layout_config = {
      height = 0.2
    }
  }
  previewer = false,
}
```

If no theme is provided, the deafult one (`dropdown`) will be used instead.
